### PR TITLE
Add 'yes' option which is skipping confirmation dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Flags:
   -n, --no-color     dont color output
   -e, --url string   schema registry url, overrides SCHEMA_REGISTRY_URL (default "http://localhost:8081")
   -v, --verbose      be verbose
+  -y, --yes          skip confirmation dialog
 
 Use "schema-registry-cli [command] --help" for more information about a command.
 ```

--- a/schema-registry-cli/cmd/delete.go
+++ b/schema-registry-cli/cmd/delete.go
@@ -18,18 +18,20 @@ var deleteCmd = &cobra.Command{
 
 		subject := args[0]
 
-		prompt := promptui.Prompt{
-			Label: fmt.Sprintf("Warning! You are deleting the subject '%s'. Are you sure", subject),
-			IsConfirm: true,
+		if !noConfirmation {
+			prompt := promptui.Prompt{
+				Label:     fmt.Sprintf("Warning! You are deleting the subject '%s'. Are you sure", subject),
+				IsConfirm: true,
+			}
+
+			_, err := prompt.Run()
+			if err != nil {
+				fmt.Printf("Aborted.\n")
+				return nil
+			}
 		}
 
-		_, err := prompt.Run()
-		if err != nil {
-			fmt.Printf("Aborted.\n")
-			return nil
-		}
-
-		err = deleteSubject(subject)
+		err := deleteSubject(subject)
 		if err != nil {
 			return err
 		}

--- a/schema-registry-cli/cmd/root.go
+++ b/schema-registry-cli/cmd/root.go
@@ -20,6 +20,7 @@ var (
 	basicAuthPass string
 	verbose       bool
 	nocolor       bool
+	noConfirmation bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -53,6 +54,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&registryURL, "url", "e", schemaregistry.DefaultURL, "schema registry url, overrides SCHEMA_REGISTRY_URL")
 	RootCmd.PersistentFlags().StringVarP(&basicAuthUser, "basic-auth-user", "u", "", "User for basic auth, overrides SCHEMA_REGISTRY_BASIC_AUTH_USER")
 	RootCmd.PersistentFlags().StringVarP(&basicAuthPass, "basic-auth-pass", "p", "", "Password for basic auth, overrides SCHEMA_REGISTRY_BASIC_AUTH_PASS")
+	RootCmd.PersistentFlags().BoolVarP(&noConfirmation, "yes", "y", false, "skip confirmation prompt")
 	viper.SetEnvPrefix("schema_registry")
 	viper.BindPFlag("url", RootCmd.PersistentFlags().Lookup("url"))
 	viper.BindEnv("url")


### PR DESCRIPTION
This PR adds a new command line option `-y`/`--yes` which is skipping confirmation dialogs.
When we use `schema-registry-cli` command in shell scripts, we often want to skip confirmation dialogs and this new option is allowing us to do that.