### PR TITLE
Support compatibility configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Available Commands:
   exists      checks if the schema provided through stdin exists for the subject
   get         retrieves a schema specified by id or subject
   get-config  retrieves global or suject specific configuration
+  set-config  set global or subject specific configuration
   subjects    lists all registered subjects
   versions    lists all available versions
 

--- a/client.go
+++ b/client.go
@@ -654,8 +654,8 @@ func (c *Client) getConfigSubject(subject string) (ConfigGet, error) {
 
 	path := fmt.Sprintf("/config/%s", subject)
 	resp, respErr := c.do(http.MethodGet, path, "", nil)
-	if respErr != nil && respErr.(ResourceError).ErrorCode != 404 {
-		return config, respErr
+	if respErr != nil && subject != "" && respErr.(ResourceError).ErrorCode != 404 {
+		return c.getConfigSubject("")
 	}
 	if resp != nil {
 		err = c.readJSON(resp, &config)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/coursehero/schema-registry
+module github.com/WildBeavers/schema-registry
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,7 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nicksnyder/go-i18n v2.0.3+incompatible h1:XCCaWsCoy4KlWkhOr+63dkv6oJmitJ573uJqDBAiFiQ=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/schema-registry-cli/cmd/compatible.go
+++ b/schema-registry-cli/cmd/compatible.go
@@ -11,8 +11,8 @@ import (
 var compatibleCmd = &cobra.Command{
 	Use:   "compatible <subject> [version]",
 	Short: "tests compatibility between a schema from stdin and a given subject",
-	Long: `The compatibility level of the subject is used for this check.
-If it has never been changed, the global compatibility level applies.
+	Long: `The compatibility type of the subject is used for this check.
+If it has never been changed, the global compatibility type applies.
 If no schema version is specified, the latest version is tested.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/schema-registry-cli/cmd/get_config.go
+++ b/schema-registry-cli/cmd/get_config.go
@@ -8,12 +8,15 @@ import (
 
 var getConfigCmd = &cobra.Command{
 	Use:   "get-config [subject]",
-	Short: "retrieves global or suject specific configuration",
-	Long: `Configuration can be requested for all or a specific subject. When "compatibility-level"
-is not defined for a specific subject, then it's using global compatibility level. To check global
-setting just call "get-config" without arguments.
-Compatibility levels in Schema-Registry may be: "NONE", "BACKWARD", "FORWARD" and "FULL". Please
-consider official documentation for more details.
+	Short: "retrieves global or subject specific configuration",
+	Long: `Configuration can be requested for all or a specific subject. 
+When "compatibility-type" is not defined for a specific subject,
+then it's using global compatibility type. To check global setting
+just call "get-config" without arguments.
+Compatibility types in Schema-Registry may be: "NONE", "BACKWARD",
+"BACKWARD_TRANSITIVE", "FORWARD", "FORWARD_TRANSITIVE", "FULL" and
+"FULL_TRANSITIVE".
+Please consider official documentation for more details.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch {

--- a/schema-registry-cli/cmd/helpers.go
+++ b/schema-registry-cli/cmd/helpers.go
@@ -64,14 +64,14 @@ func getBySubjectVersion(subj string, ver int) error {
 	return nil
 }
 
-func printConfig(cfg schemaregistry.Config, subj string) {
+func printConfig(cfg schemaregistry.ConfigGet, subj string) {
 	if subj == "" {
 		subj = "global"
 	}
-	if cfg.CompatibilityLevel == "" {
-		cfg.CompatibilityLevel = "not defined, using global"
+	if cfg.CompatibilityType == "" {
+		cfg.CompatibilityType = "not defined, using global"
 	}
-	fmt.Printf("%s compatibility-level: %s\n", subj, cfg.CompatibilityLevel)
+	fmt.Printf("%s compatibility type: %s\n", subj, cfg.CompatibilityType)
 }
 
 func getConfig(subj string) error {

--- a/schema-registry-cli/cmd/helpers.go
+++ b/schema-registry-cli/cmd/helpers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hokaccha/go-prettyjson"
 	"github.com/spf13/viper"
 
-	schemaregistry "github.com/coursehero/schema-registry"
+	schemaregistry "github.com/WildBeavers/schema-registry"
 )
 
 func stdinToString() string {

--- a/schema-registry-cli/cmd/root.go
+++ b/schema-registry-cli/cmd/root.go
@@ -10,16 +10,16 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	schemaregistry "github.com/coursehero/schema-registry"
+	schemaregistry "github.com/WildBeavers/schema-registry"
 )
 
 var (
-	cfgFile       string
-	registryURL   string
-	basicAuthUser string
-	basicAuthPass string
-	verbose       bool
-	nocolor       bool
+	cfgFile        string
+	registryURL    string
+	basicAuthUser  string
+	basicAuthPass  string
+	verbose        bool
+	nocolor        bool
 	noConfirmation bool
 )
 

--- a/schema-registry-cli/cmd/set_config.go
+++ b/schema-registry-cli/cmd/set_config.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+
+	schemaregistry "github.com/coursehero/schema-registry"
+	"github.com/spf13/cobra"
+)
+
+// constants for parameter names
+const (
+	Compatibility = "compatibility-type"
+)
+
+var (
+	compatibility string
+)
+
+var setConfigCmd = &cobra.Command{
+	Use:   "set-config [subject]",
+	Short: "set global or subject specific configuration",
+	Long: `Configuration currently contains only the compatibility type.
+It can be set for all or a specific subject. 
+Compatibility types in Schema-Registry may be: "NONE", "BACKWARD",
+"BACKWARD_TRANSITIVE", "FORWARD", "FORWARD_TRANSITIVE", "FULL" and
+"FULL_TRANSITIVE".
+Please consider official documentation for more details.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch {
+		case len(args) > 1:
+			return fmt.Errorf("only one subject allowed")
+		case len(args) == 0:
+			if err := setConfig("", compatibility); err != nil {
+				return err
+			}
+		case len(args) == 1:
+			if err := setConfig(args[0], compatibility); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(setConfigCmd)
+	setConfigCmd.PersistentFlags().StringVar(&compatibility, Compatibility, "", "compatibility level to set")
+	setConfigCmd.MarkFlagRequired(Compatibility)
+}
+
+func setConfig(subj string, compatibilityType string) error {
+	client := assertClient()
+	return client.SetConfig(subj, schemaregistry.ConfigPut{CompatibilityType: schemaregistry.CompatibilityType(compatibilityType)})
+}

--- a/schema-registry-cli/cmd/set_config.go
+++ b/schema-registry-cli/cmd/set_config.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	schemaregistry "github.com/coursehero/schema-registry"
+	schemaregistry "github.com/WildBeavers/schema-registry"
 	"github.com/spf13/cobra"
 )
 

--- a/schema-registry-cli/main.go
+++ b/schema-registry-cli/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/coursehero/schema-registry/schema-registry-cli/cmd"
+import "github.com/WildBeavers/schema-registry/schema-registry-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
- use phrase "compatibility type" instead of "compatibility level"
- list also TRANSITIVE compatibility types
- add new command set-config

fixes [#5 Support compatibility configuration](https://github.com/lensesio/schema-registry/issues/5)